### PR TITLE
macOS: make sure standard framework location is searched

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -16,6 +16,7 @@
         },
         "link_settings": {
           "libraries": [
+            '-F/Library/Frameworks',
             '-framework', 'DeckLinkAPI'
           ]
         },


### PR DESCRIPTION
From  rezonant / macadam fork. This fixes install of macadam on OSX, see issue #19:
node-gyp fails: 'framework not found DeckLinkAPI' on Mac