### PR TITLE
fixed linux compile error

### DIFF
--- a/src/macadam.cc
+++ b/src/macadam.cc
@@ -2006,7 +2006,7 @@ napi_value setDeviceConfig(napi_env env, napi_callback_info info) {
         status = napi_get_value_bool(env, param, &cFlag);
         flag = cFlag == TRUE ? true : false;
         #else
-        status = napi_get_value_bool(env, param, flag);
+        status = napi_get_value_bool(env, param, &flag);
         #endif
         CHECK_BAIL;
         hresult = deckLinkConfig->SetFlag(knownConfigValues[configIndex], flag);


### PR DESCRIPTION
I'm getting the following error:

> make: Entering directory '/root/node_modules/macadam/build'
>   CXX(target) Release/obj.target/macadam/src/macadam_util.o
>   CXX(target) Release/obj.target/macadam/src/macadam.o
> ../src/macadam.cc: In function ‘napi_value__* setDeviceConfig(napi_env, napi_callback_info)’:
> ../src/macadam.cc:2009:54: error: cannot convert ‘bool’ to ‘bool*’ for argument ‘3’ to ‘napi_status napi_get_value_bool(napi_env, napi_value, bool*)’
>          status = napi_get_value_bool(env, param, flag);
>                                                       ^
> macadam.target.mk:113: recipe for target 'Release/obj.target/macadam/src/macadam.o' failed
> make: *** [Release/obj.target/macadam/src/macadam.o] Error 1
> make: Leaving directory '/root/node_modules/macadam/build'
> gyp ERR! build error
> gyp ERR! stack Error: `make` failed with exit code: 2
> gyp ERR! stack     at ChildProcess.onExit (/usr/lib/node_modules/node-gyp/lib/build.js:194:23)
> gyp ERR! stack     at ChildProcess.emit (events.js:219:5)
> gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:274:12)
> gyp ERR! System Linux 4.19.13-rbtv
> gyp ERR! command "/usr/bin/node" "/usr/bin/node-gyp" "rebuild"
> gyp ERR! cwd /root/node_modules/macadam
> gyp ERR! node -v v13.3.0
> gyp ERR! node-gyp -v v7.0.0
> gyp ERR! not ok


It seemed, that two lines above my commit on the windows version it is correct (using as reference).