### PR TITLE
fix: guard against failing to initialise

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -24,13 +24,15 @@
         ]
       }],
       ['OS=="linux"', {
-        'sources' : [ "src/macadam_util.cc", "src/macadam.cc",
-          "src/capture_promise.cc", "src/playback_promise.cc",
-          "src/timecode.cc" ],
+        'sources' : [ 
+          "src/macadam_util.cc",
+          "src/macadam.cc",
+          "src/capture_promise.cc",
+          "src/playback_promise.cc",
+          "src/timecode.cc",
+          "decklink/Linux/include/DeckLinkAPIDispatch.cpp"
+        ],
         'link_settings' : {
-          "libraries": [
-            "/usr/lib/libDeckLinkAPI.so"
-          ],
           "ldflags" : [
             "-lm -ldl -lpthread"
 	      ]

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "install": "node-gyp rebuild",
+    "build": "node-gyp rebuild",
     "test": "tape test/*Spec.js",
     "lint": "eslint index.js **/*.js"
   },

--- a/scratch/list_devices.js
+++ b/scratch/list_devices.js
@@ -1,0 +1,20 @@
+/* Copyright 2018 Streampunk Media Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const macadam = require('../');
+
+console.log(`Decklink SDK Version: ${macadam.deckLinkVersion()}`)
+
+console.log('Devices', JSON.stringify(macadam.getDeviceInfo(), undefined, 4))

--- a/src/capture_promise.cc
+++ b/src/capture_promise.cc
@@ -186,6 +186,11 @@ void captureExecute(napi_env env, void* data) {
   #else
   deckLinkIterator = CreateDeckLinkIteratorInstance();
   #endif
+  if (deckLinkIterator == nullptr) {
+    c->status = MACADAM_ERROR_START;
+    c->errorMsg = "Unable to load DeckLinkAPI.";
+    return;
+  }
 
   for ( uint32_t x = 0 ; x <= c->deviceIndex ; x++ ) {
     if (deckLinkIterator->Next(&deckLink) != S_OK) {

--- a/src/macadam.cc
+++ b/src/macadam.cc
@@ -418,6 +418,7 @@ napi_value deckLinkVersion(napi_env env, napi_callback_info info) {
   #else
   deckLinkIterator = CreateDeckLinkIteratorInstance();
   #endif
+  if (deckLinkIterator == nullptr) NAPI_THROW_ERROR("Unable to load DeckLinkAPI.");
 
   hresult = deckLinkIterator->QueryInterface(IID_IDeckLinkAPIInformation, (void**)&deckLinkAPIInformation);
   if (hresult != S_OK) NAPI_THROW_ERROR("Error connecting to DeckLinkAPI.");
@@ -460,6 +461,8 @@ napi_value getFirstDevice(napi_env env, napi_callback_info info) {
   #else
   deckLinkIterator = CreateDeckLinkIteratorInstance();
   #endif
+  if (deckLinkIterator == nullptr) NAPI_THROW_ERROR("Unable to load DeckLinkAPI.");
+
   if (deckLinkIterator->Next(&deckLink) != S_OK) {
     status = napi_get_undefined(env, &result);
     if (checkStatus(env, status, __FILE__, __LINE__ - 1) != napi_ok) {
@@ -521,6 +524,7 @@ napi_value getDeviceInfo(napi_env env, napi_callback_info info) {
   #else
   deckLinkIterator = CreateDeckLinkIteratorInstance();
   #endif
+  if (deckLinkIterator == nullptr) NAPI_THROW_ERROR("Unable to load DeckLinkAPI.");
 
   uint32_t index = 0;
   while (deckLinkIterator->Next(&deckLink) == S_OK) {
@@ -1738,6 +1742,7 @@ napi_value getDeviceConfig(napi_env env, napi_callback_info info) {
   #else
   deckLinkIterator = CreateDeckLinkIteratorInstance();
   #endif
+  if (deckLinkIterator == nullptr) NAPI_THROW_ERROR("Unable to load DeckLinkAPI.");
 
   for ( uint32_t x = 0 ; x <= deviceIndex ; x++ ) {
     if (deckLinkIterator->Next(&deckLink) != S_OK) {
@@ -1947,6 +1952,7 @@ napi_value setDeviceConfig(napi_env env, napi_callback_info info) {
   #else
   deckLinkIterator = CreateDeckLinkIteratorInstance();
   #endif
+  if (deckLinkIterator == nullptr) NAPI_THROW_ERROR("Unable to load DeckLinkAPI.");
 
   for ( uint32_t x = 0 ; x <= deviceIndex ; x++ ) {
     if (deckLinkIterator->Next(&deckLink) != S_OK) {

--- a/src/playback_promise.cc
+++ b/src/playback_promise.cc
@@ -104,6 +104,11 @@ void playbackExecute(napi_env env, void* data) {
   #else
   deckLinkIterator = CreateDeckLinkIteratorInstance();
   #endif
+  if (deckLinkIterator == nullptr) {
+    c->status = MACADAM_ERROR_START;
+    c->errorMsg = "Unable to load DeckLinkAPI.";
+    return;
+  }
 
   for ( uint32_t x = 0 ; x <= c->deviceIndex ; x++ ) {
     if (deckLinkIterator->Next(&deckLink) != S_OK) {


### PR DESCRIPTION
Simply null guard after trying to create the deckLinkIterator as systems without the sdk installed will return null here. Instead throw a js exception which can be handled by the library user
Also, for linux this removes the linking against the sdk library, and includes the sdk cpp to allow for dynamic loading of the library.

Checked on:
* Linux without sdk
* Linux with sdk
* Windows without sdk

fixes #24 