### PR TITLE
fix: Build fail

### DIFF
--- a/src/capture_promise.cc
+++ b/src/capture_promise.cc
@@ -82,13 +82,13 @@ HRESULT captureThreadsafe::VideoInputFormatChanged(
   return E_FAIL;
 }
 
-void finalizeCaptureCarrier(napi_env env, void* finalize_data, void* finalize_hint) {
+void finalizeCaptureCarrier(node_api_basic_env env, void* finalize_data, void* finalize_hint) {
   // printf("Finalizing capture threadsafe.\n");
   captureThreadsafe* c = (captureThreadsafe*) finalize_data;
   delete c;
 }
 
-void finalizeVideoBuffer(napi_env env, void* finalize_data, void* finalize_hint) {
+void finalizeVideoBuffer(node_api_basic_env env, void* finalize_data, void* finalize_hint) {
   napi_status status;
   int64_t externalMemory;
   IDeckLinkVideoInputFrame* video = (IDeckLinkVideoInputFrame*) finalize_hint;
@@ -99,7 +99,7 @@ void finalizeVideoBuffer(napi_env env, void* finalize_data, void* finalize_hint)
   // printf("Releasing video frame - ext mem now %li\n", externalMemory);
 }
 
-void finalizeAudioPacket(napi_env env, void* finalize_data, void* finalize_hint) {
+void finalizeAudioPacket(node_api_basic_env env, void* finalize_data, void* finalize_hint) {
   napi_status status;
   int64_t externalMemory = 0;
   audioData* audio = (audioData*) finalize_hint;

--- a/src/playback_promise.cc
+++ b/src/playback_promise.cc
@@ -82,7 +82,7 @@ HRESULT playbackThreadsafe::ScheduledPlaybackHasStopped() {
   return S_OK;
 }
 
-void finalizePlaybackCarrier(napi_env env, void* finalize_data, void* finalize_hint) {
+void finalizePlaybackCarrier(node_api_basic_env env, void* finalize_data, void* finalize_hint) {
   // printf("Finalizing playback threadsafe.\n");
   playbackThreadsafe* c = (playbackThreadsafe*) finalize_data;
   delete c;


### PR DESCRIPTION
This PR fixes an issue where the node-gyp build/compile fails.

Before the fix, I got the following error message on `npm run build`:
```
 macadam_util.cc
  macadam.cc
  capture_promise.cc
C:\macadam-test\node_modules\macadam\src\capture_promise.cc(460,15): error C2664: 'napi_status napi_create
_external(napi_env,void *,node_api_basic_finalize,void *,napi_value *)': cannot convert argument 3 from 'void (__cdecl *)(n
api_env,void *,void *)' to 'node_api_basic_finalize' [C:\macadam-test\node_modules\macadam\build\macadam.v
cxproj]
      C:\macadam-test\node_modules\macadam\src\capture_promise.cc(460,47):
      None of the functions with this name in scope match the target type
      C:\Users\xpro1caspar01\AppData\Local\node-gyp\Cache\22.22.3\include\node\js_native_api.h(319,1):
      see declaration of 'napi_create_external'
      C:\macadam-test\node_modules\macadam\src\capture_promise.cc(460,15):
      while trying to match the argument list '(napi_env, captureThreadsafe *, overloaded-function, nullptr, napi_value *)'
  
C:\macadam-test\node_modules\macadam\src\capture_promise.cc(701,17): error C2664: 'napi_status napi_create
_external_buffer(napi_env,size_t,void *,node_api_basic_finalize,void *,napi_value *)': cannot convert argument 4 from 'void
 (__cdecl *)(napi_env,void *,void *)' to 'node_api_basic_finalize' [C:\macadam-test\node_modules\macadam\b
uild\macadam.vcxproj]
      C:\macadam-test\node_modules\macadam\src\capture_promise.cc(702,7):
      None of the functions with this name in scope match the target type
      C:\Users\xpro1caspar01\AppData\Local\node-gyp\Cache\22.22.3\include\node\node_api.h(124,1):
      see declaration of 'napi_create_external_buffer'
      C:\macadam-test\node_modules\macadam\src\capture_promise.cc(701,17):
      while trying to match the argument list '(napi_env, int32_t, void *, overloaded-function, IDeckLinkVideoInputFrame *,
   napi_value *)'
  
C:\macadam-test\node_modules\macadam\src\capture_promise.cc(857,19): error C2664: 'napi_status napi_create
_external_buffer(napi_env,size_t,void *,node_api_basic_finalize,void *,napi_value *)': cannot convert argument 4 from 'void
 (__cdecl *)(napi_env,void *,void *)' to 'node_api_basic_finalize' [C:\macadam-test\node_modules\macadam\b
uild\macadam.vcxproj]
      C:\macadam-test\node_modules\macadam\src\capture_promise.cc(858,45):
      None of the functions with this name in scope match the target type
      C:\Users\xpro1caspar01\AppData\Local\node-gyp\Cache\22.22.3\include\node\node_api.h(124,1):
      see declaration of 'napi_create_external_buffer'
      C:\macadam-test\node_modules\macadam\src\capture_promise.cc(857,19):
      while trying to match the argument list '(napi_env, uint32_t, void *, overloaded-function, audioData *, napi_value *)
  '
  
gyp ERR! build error 
gyp ERR! stack Error: `C:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin\MSBuild.exe` failed with exit code: 1
gyp ERR! stack at ChildProcess.<anonymous> (C:\macadam-test\node_modules\node-gyp\lib\build.js:219:23)
gyp ERR! stack at ChildProcess.emit (node:events:519:28)
gyp ERR! stack at ChildProcess._handle.onexit (node:internal/child_process:293:12)
gyp ERR! System Windows_NT 10.0.26100
gyp ERR! command "C:\\nvm4w\\nodejs\\node.exe" "C:\\macadam-test\\node_modules\\node-gyp\\bin\\node-gyp.js" "rebuild"
gyp ERR! cwd C:\macadam-test\node_modules\macadam
gyp ERR! node -v v22.22.3
gyp ERR! node-gyp -v v12.3.0
gyp ERR! $npm_package_name macadam
gyp ERR! $npm_package_version 2.0.18
gyp ERR! not ok 
```

After the fix, it seems to work as expected.

Tested using latest Microsoft Visual Studio build tools and NodeJs 22.


_(disclaimer: Gihub Copilot was used to author the fix_